### PR TITLE
修复连接超时时message返回空的问题

### DIFF
--- a/Consumer.php
+++ b/Consumer.php
@@ -83,6 +83,11 @@ class KafKa_Consumer {
      */
     public function consume() {
         $message = $this->topic->consume($this->partition, $this->timeout * 1000);
+
+	if (empty($message)) {
+	    return null;
+	}
+
         switch ($message->err) {
             case RD_KAFKA_RESP_ERR_NO_ERROR:
                 return $message;


### PR DESCRIPTION
https://arnaud-lb.github.io/php-rdkafka/phpdoc/rdkafka-consumertopic.consume.html
在rdkafka官方文档中可以看到
Returns a RdKafka\Message or NULL on timeout.
在超时时会返回null，这个时候会导致sdk抛出语法错误问题